### PR TITLE
Fixed 'an invalid Peer was used' when starting a session

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -52,9 +52,10 @@ class Monitor:
         self.api_id = api_id
         self.api_hash = api_hash
         self.bot_token = bot_token
+        self.session_name = session_name
 
         # creating a Telegram session and assigning it to a variable client
-        client = TelegramClient('bot', self.api_id, self.api_hash)
+        client = TelegramClient(self.session_name, self.api_id, self.api_hash)
         client.parse_mode = 'html'
         client.start(bot_token=self.bot_token)
 

--- a/parameters.py
+++ b/parameters.py
@@ -3,6 +3,7 @@ username = ''       # Your Telegram username (messages will be sent to this user
 api_id = ''         # Telegram bot API ID (usually an 8-digit number)
 api_hash = ''       # Telegram bot API hash
 bot_token = ''      # Telegram bot token
+session_name = ''   # A unique name to create the virtual telegram client
 
 # general settings
 polling_interval_seconds = 60  # recommended to make it > 10 seconds to account for processing time, make it > 30 when using random proxies


### PR DESCRIPTION
A unique session name may be required. Adding it to parameters.py prevents a PeerIdInvalidError from being thrown when initializing a session.