### PR TITLE
fixed issue with getlog command

### DIFF
--- a/remote.py
+++ b/remote.py
@@ -183,7 +183,7 @@ class TelegramConnection:
         @client.on(events.NewMessage(pattern="(?i)/getlog"))
         async def handle_get_log(event):
             self.monitor.save_df()
-            callbacks.send_logfile(self.monitor.get_logfile_path())
+            await callbacks.send_logfile(self.monitor.get_logfile_path())
 
         # plotprocessingtime handler
         @client.on(events.NewMessage(pattern="(?i)/plotprocessingtime"))


### PR DESCRIPTION
## Pull Request Description

### Summary
This pull request addresses a fix in the `getlog` command handler by modifying the `send_logfile` function to be asynchronous, ensuring compatibility and proper functionality within the asynchronous event handler.

### Changes Made
- **File Modified**: `remote.py`
- **Changes**: 
  - One line removed and one line added to convert `callbacks.send_logfile` into an asynchronous call with `await`.

### Purpose
The fix resolves an issue with the `getlog` command, where the `send_logfile` function was not executed as an asynchronous operation, potentially causing delayed or failed file sending. This change allows the function to work seamlessly within the asynchronous `handle_get_log` event.

### Impact
- Ensures proper functionality and performance of the `getlog` command.
- Improves overall system responsiveness and error handling for asynchronous tasks.

### Testing
- Verified that `getlog` command successfully retrieves and sends the logfile.
- Ensured no further dependencies are impacted by this change.

---

Please review and provide feedback.
